### PR TITLE
[Feat] Comment 대댓글(부모 댓글) 지원 1차 MVP 확장 구현

### DIFF
--- a/src/main/java/back/sw/domain/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/back/sw/domain/comment/dto/request/CommentCreateRequest.java
@@ -4,6 +4,10 @@ import jakarta.validation.constraints.NotBlank;
 
 public record CommentCreateRequest(
         @NotBlank(message = "댓글 내용은 필수입니다.")
-        String content
+        String content,
+        Integer parentId
 ) {
+    public CommentCreateRequest(String content) {
+        this(content, null);
+    }
 }

--- a/src/main/java/back/sw/domain/comment/entity/Comment.java
+++ b/src/main/java/back/sw/domain/comment/entity/Comment.java
@@ -65,6 +65,16 @@ public class Comment extends BaseEntity {
         return new Comment(post, member, anonymousProfile, null, content);
     }
 
+    public static Comment createReply(
+            Post post,
+            Member member,
+            CommentAnonymousProfile anonymousProfile,
+            Comment parent,
+            String content
+    ) {
+        return new Comment(post, member, anonymousProfile, parent, content);
+    }
+
     public void softDelete() {
         this.deleted = true;
     }
@@ -91,6 +101,10 @@ public class Comment extends BaseEntity {
 
     public int postId() {
         return post.getId();
+    }
+
+    public Integer parentId() {
+        return parent == null ? null : parent.getId();
     }
 
     public void decreasePostCommentCount() {

--- a/src/main/java/back/sw/domain/comment/service/CommentService.java
+++ b/src/main/java/back/sw/domain/comment/service/CommentService.java
@@ -38,9 +38,12 @@ public class CommentService {
         Post post = getPost(postId);
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ServiceException("404-1", "회원을 찾을 수 없습니다."));
+        Comment parent = getParentComment(postId, request.parentId());
 
         CommentAnonymousProfile profile = getOrCreateAnonymousProfile(post, member);
-        Comment comment = Comment.create(post, member, profile, request.content());
+        Comment comment = parent == null
+                ? Comment.create(post, member, profile, request.content())
+                : Comment.createReply(post, member, profile, parent, request.content());
         commentRepository.save(comment);
         post.increaseCommentCount();
 
@@ -95,6 +98,15 @@ public class CommentService {
     private Post getPost(int postId) {
         return postRepository.findByIdAndDeletedFalse(postId)
                 .orElseThrow(() -> new ServiceException("404-1", "게시글을 찾을 수 없습니다."));
+    }
+
+    private Comment getParentComment(int postId, Integer parentId) {
+        if (parentId == null) {
+            return null;
+        }
+
+        return commentRepository.findByIdAndPostId(parentId, postId)
+                .orElseThrow(() -> new ServiceException("404-1", "부모 댓글을 찾을 수 없습니다."));
     }
 
     private CommentAnonymousProfile getOrCreateAnonymousProfile(Post post, Member member) {

--- a/src/test/java/back/sw/domain/comment/controller/CommentIntegrationTest.java
+++ b/src/test/java/back/sw/domain/comment/controller/CommentIntegrationTest.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -207,6 +208,47 @@ class CommentIntegrationTest {
         ).andExpect(status().isBadRequest());
     }
 
+    @Test
+    void 대댓글_작성_성공() throws Exception {
+        String writerToken = registerAndLogin("commentwriter9@univ.ac.kr", "20251027", "writer9");
+        String replierToken = registerAndLogin("commentuser9@univ.ac.kr", "20251028", "user9");
+        int postId = createPost(writerToken, "FREE", "대댓글 테스트", "본문", List.of());
+        int parentCommentId = createComment(postId, writerToken, "부모 댓글");
+
+        createComment(postId, replierToken, "대댓글", parentCommentId);
+
+        MvcResult listResult = mockMvc.perform(get("/api/v1/posts/{postId}/comments", postId))
+                .andExpect(status().isOk())
+                .andReturn();
+        JsonNode items = objectMapper.readTree(listResult.getResponse().getContentAsString())
+                .get("data")
+                .get("items");
+
+        assertEquals(2, items.size());
+        assertEquals("대댓글", items.get(0).get("content").asText());
+        assertEquals("부모 댓글", items.get(1).get("content").asText());
+    }
+
+    @Test
+    void 다른_게시글_댓글을_부모로_대댓글_요청시_404() throws Exception {
+        String writerToken = registerAndLogin("commentwriter10@univ.ac.kr", "20251029", "writer10");
+        String replierToken = registerAndLogin("commentuser10@univ.ac.kr", "20251030", "user10");
+
+        int firstPostId = createPost(writerToken, "FREE", "첫 게시글", "본문1", List.of());
+        int secondPostId = createPost(writerToken, "FREE", "둘째 게시글", "본문2", List.of());
+        int foreignParentCommentId = createComment(secondPostId, writerToken, "다른 글 댓글");
+
+        mockMvc.perform(
+                post("/api/v1/posts/{postId}/comments", firstPostId)
+                        .header("Authorization", "Bearer " + replierToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "content", "대댓글 시도",
+                                "parentId", foreignParentCommentId
+                        )))
+        ).andExpect(status().isNotFound());
+    }
+
     private String registerAndLogin(String email, String studentNumber, String nickname) throws Exception {
         mockMvc.perform(
                 post("/api/v1/members")
@@ -270,11 +312,21 @@ class CommentIntegrationTest {
     }
 
     private int createComment(int postId, String accessToken, String content) throws Exception {
+        return createComment(postId, accessToken, content, null);
+    }
+
+    private int createComment(int postId, String accessToken, String content, Integer parentId) throws Exception {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("content", content);
+        if (parentId != null) {
+            payload.put("parentId", parentId);
+        }
+
         MvcResult createResult = mockMvc.perform(
                         post("/api/v1/posts/{postId}/comments", postId)
                                 .header("Authorization", "Bearer " + accessToken)
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(Map.of("content", content)))
+                                .content(objectMapper.writeValueAsString(payload))
                 ).andExpect(status().isCreated())
                 .andReturn();
 

--- a/src/test/java/back/sw/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/back/sw/domain/comment/service/CommentServiceTest.java
@@ -96,6 +96,58 @@ class CommentServiceTest {
     }
 
     @Test
+    void createReplyWithParentCommentSuccess() {
+        Member postWriter = createMember(1, "writer@univ.ac.kr", "20250001", "writer");
+        Member replier = createMember(2, "user@univ.ac.kr", "20250002", "user");
+        Post post = createPost(10, postWriter, "제목", "내용");
+
+        CommentAnonymousProfile writerProfile = CommentAnonymousProfile.create(post, postWriter, 1);
+        Comment parentComment = Comment.create(post, postWriter, writerProfile, "부모 댓글");
+        ReflectionTestUtils.setField(parentComment, "id", 50);
+
+        when(postRepository.findByIdAndDeletedFalse(10)).thenReturn(Optional.of(post));
+        when(memberRepository.findById(2)).thenReturn(Optional.of(replier));
+        when(commentRepository.findByIdAndPostId(50, 10)).thenReturn(Optional.of(parentComment));
+        when(commentAnonymousProfileRepository.findByPostIdAndMemberId(10, 2)).thenReturn(Optional.empty());
+        when(commentAnonymousProfileRepository.findTopByPostIdOrderByAnonymousNoDesc(10))
+                .thenReturn(Optional.of(writerProfile));
+        when(commentAnonymousProfileRepository.save(any(CommentAnonymousProfile.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(commentRepository.save(any(Comment.class))).thenAnswer(invocation -> {
+            Comment saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", 101);
+            return saved;
+        });
+
+        CommentCreateResponse response = commentService.create(2, 10, new CommentCreateRequest("대댓글", 50));
+
+        assertEquals(101, response.commentId());
+        assertEquals(1, post.getCommentCount());
+        ArgumentCaptor<Comment> captor = ArgumentCaptor.forClass(Comment.class);
+        verify(commentRepository).save(captor.capture());
+        assertEquals(50, captor.getValue().parentId());
+    }
+
+    @Test
+    void createReplyFailsWhenParentNotFound() {
+        Member postWriter = createMember(1, "writer@univ.ac.kr", "20250001", "writer");
+        Member replier = createMember(2, "user@univ.ac.kr", "20250002", "user");
+        Post post = createPost(10, postWriter, "제목", "내용");
+
+        when(postRepository.findByIdAndDeletedFalse(10)).thenReturn(Optional.of(post));
+        when(memberRepository.findById(2)).thenReturn(Optional.of(replier));
+        when(commentRepository.findByIdAndPostId(999, 10)).thenReturn(Optional.empty());
+
+        ServiceException exception = assertThrows(
+                ServiceException.class,
+                () -> commentService.create(2, 10, new CommentCreateRequest("대댓글", 999))
+        );
+
+        assertEquals("404-1", exception.getRsData().resultCode());
+        assertEquals("부모 댓글을 찾을 수 없습니다.", exception.getRsData().msg());
+    }
+
+    @Test
     void getListReturnsAnonymousLabelAndPostAuthorBadge() {
         Member postWriter = createMember(1, "writer@univ.ac.kr", "20250001", "writer");
         Member otherMember = createMember(2, "user@univ.ac.kr", "20250002", "user");


### PR DESCRIPTION
## 🔗 Issue 번호
- close #23

## 🛠 작업 내역
- 댓글 생성 요청에 부모 댓글 ID(`parentId`) 선택 입력 지원
- 대댓글 생성 로직 추가 (`Comment.parent` 연결)
- 부모 댓글 유효성 검증(동일 게시글 내 존재 여부) 추가
- 대댓글 생성 성공/실패 단위/통합 테스트 보강

## 🔄 변경 사항
- `CommentCreateRequest` 확장
  - `parentId` 필드 추가(기존 생성자 호환 유지)
- `Comment` 엔티티 확장
  - `createReply(...)` 팩토리 메서드 추가
  - `parentId()` 조회 메서드 추가
- `CommentService` 확장
  - 댓글 생성 시 부모 댓글 조회/검증 로직 추가
  - 부모 댓글 지정 시 대댓글 생성
- 테스트 보강
  - `CommentServiceTest`: 대댓글 생성 성공/부모 댓글 없음 실패 케이스 추가
  - `CommentIntegrationTest`: 대댓글 생성 성공, 다른 게시글 댓글을 부모로 지정 시 404 케이스 추가

## 📦 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩터링
- [ ] 문서 업데이트

## ✅ 체크리스트
- [x] Merge 대상 branch가 올바른가?
- [x] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?

## 테스트 결과
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew test --tests "back.sw.domain.comment.service.CommentServiceTest" --tests "back.sw.domain.comment.controller.CommentIntegrationTest"` 통과
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew check` 통과

## 영향 범위
- API:
  - `POST /api/v1/posts/{postId}/comments` 요청 스키마 확장 (`parentId`)
- DB: `comments.parent_id` 사용 (기존 스키마 활용)
- Config: 없음
- Domain: `comment`, `post`