### PR TITLE
[Chore] 민감정보 관리 강화 및 환경변수 기반 설정 정리 (#31)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Security
+CUSTOM_JWT_SECRET_KEY=replace-with-64+-char-random-string
+CUSTOM_JWT_ACCESS_EXPIRATION_SECONDS=1800
+CUSTOM_JWT_REFRESH_EXPIRATION_SECONDS=1209600
+
+# Database (dev/prod profiles)
+DB_HOST=localhost
+DB_PORT=3306
+DB_NAME=swconnect_dev
+DB_USERNAME=root
+DB_PASSWORD=
+
+# CORS
+CUSTOM_CORS_ALLOWED_ORIGIN_PATTERNS=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,19 @@ build/
 
 # Sensitive local data
 secrets/
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+*.p12
+*.jks
+*.tfstate
+*.tfstate.*
+*.tfvars
+*.tfvars.json
+uploads/
+logs/
 
 ### STS ###
 .apt_generated

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,7 +35,7 @@ file:
 
 custom:
   jwt:
-    secret-key: ${CUSTOM_JWT_SECRET_KEY:abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789}
+    secret-key: ${CUSTOM_JWT_SECRET_KEY}
     access-token-expiration-seconds: ${CUSTOM_JWT_ACCESS_EXPIRATION_SECONDS:1800}
     refresh-token-expiration-seconds: ${CUSTOM_JWT_REFRESH_EXPIRATION_SECONDS:1209600}
   cors:


### PR DESCRIPTION
## 작업 요약
- 민감 파일이 원격에 커밋되지 않도록 `.gitignore` 보안 패턴을 강화했습니다.
- `application.yml`의 JWT secret 기본 하드코딩 값을 제거하고 환경변수(`CUSTOM_JWT_SECRET_KEY`) 기반으로 강제했습니다.
- 로컬 설정 참고용 `.env.example`를 추가했습니다(실제 값 없음).

## 상세 변경
- `.gitignore`
  - `.env`, `.env.*`, 키/인증서 파일, Terraform 상태/변수 파일, `uploads/`, `logs/` ignore 추가
  - `.env.example`는 예외 허용
- `src/main/resources/application.yml`
  - `custom.jwt.secret-key` 기본값 제거 (`${CUSTOM_JWT_SECRET_KEY}`)
- `.env.example` 신규 추가
  - JWT/DB/CORS 관련 환경변수 템플릿 제공

## 테스트 결과
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew check`
- 결과: 성공 (JUnit, Checkstyle, SpotBugs, JaCoCo)

## 영향 범위
- API: 없음
- DB: 없음
- Config: `.gitignore`, `application.yml`, `.env.example`
- Domain: global/security

## 관련 이슈
- Closes #31