### PR TITLE
[Fix] CD 배포 권한 오류 수정 및 Docker 빌드 캐시 최적화

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,10 @@
 .git
 .github
 .gradle
+.gradle-local
 .idea
 build
+deploy
 secrets
 uploads
 logs
@@ -10,6 +12,9 @@ logs
 docs
 roles
 skills
+
+AGENTS.md
+HELP.md
 
 .env
 .env.*

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -73,6 +73,8 @@ jobs:
           tags: |
             ${{ env.image_name }}:${{ env.sha_tag }}
             ${{ env.image_name }}:${{ env.branch_latest_tag }}
+          cache-from: type=gha,scope=sw-connect-backend
+          cache-to: type=gha,mode=max,scope=sw-connect-backend
 
   deploy-validation:
     if: needs.build-and-push.outputs.head_branch == 'develop'
@@ -84,6 +86,21 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.build-and-push.outputs.head_sha }}
+
+      - name: Prepare deploy directories on VM
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.SW_VM_HOST }}
+          username: ${{ secrets.SW_VM_USER }}
+          key: ${{ secrets.SW_VM_SSH_KEY }}
+          port: ${{ secrets.SW_VM_PORT }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+            OWNER_USER="$(id -un)"
+            OWNER_GROUP="$(id -gn)"
+            sudo mkdir -p /opt/sw-connect/shared/artifacts
+            sudo chown -R "${OWNER_USER}:${OWNER_GROUP}" /opt/sw-connect
 
       - name: Upload deploy assets to VM
         uses: appleboy/scp-action@v0.1.7
@@ -133,6 +150,21 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.build-and-push.outputs.head_sha }}
+
+      - name: Prepare deploy directories on VM
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.SW_VM_HOST }}
+          username: ${{ secrets.SW_VM_USER }}
+          key: ${{ secrets.SW_VM_SSH_KEY }}
+          port: ${{ secrets.SW_VM_PORT }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+            OWNER_USER="$(id -un)"
+            OWNER_GROUP="$(id -gn)"
+            sudo mkdir -p /opt/sw-connect/shared/artifacts
+            sudo chown -R "${OWNER_USER}:${OWNER_GROUP}" /opt/sw-connect
 
       - name: Upload deploy assets to VM
         uses: appleboy/scp-action@v0.1.7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
+# syntax=docker/dockerfile:1.7
 FROM eclipse-temurin:21-jdk AS builder
 
 WORKDIR /workspace
 
 COPY gradlew settings.gradle.kts build.gradle.kts ./
 COPY gradle ./gradle
+
+RUN chmod +x ./gradlew
+RUN --mount=type=cache,target=/root/.gradle ./gradlew --no-daemon dependencies
+
 COPY config ./config
 COPY src ./src
 
-RUN chmod +x ./gradlew
-RUN ./gradlew --no-daemon bootJar
+RUN --mount=type=cache,target=/root/.gradle ./gradlew --no-daemon bootJar
 
 FROM eclipse-temurin:21-jre
 


### PR DESCRIPTION
## 작업 요약
- CD 배포 전 VM 경로 권한/디렉터리 준비 단계를 추가해 `scp` 업로드 실패를 방지했습니다.
- Docker 이미지 빌드에 Buildx GHA 캐시를 적용해 반복 빌드 시간을 단축하도록 했습니다.
- Dockerfile에 BuildKit Gradle 캐시 마운트를 적용하고 레이어를 조정해 의존성 재다운로드 비용을 줄였습니다.
- Docker 빌드 컨텍스트에서 불필요 파일(`deploy`, `.gradle-local`, 운영 문서)을 제외했습니다.

## 변경 상세
- `.github/workflows/cd.yml`
  - `build-and-push`에 `cache-from/cache-to` 추가
  - `deploy-validation`, `deploy-prod`에 `Prepare deploy directories on VM` 단계 추가
- `Dockerfile`
  - `# syntax=docker/dockerfile:1.7` 적용
  - Gradle 빌드 단계에 `--mount=type=cache,target=/root/.gradle` 적용
  - 의존성 레이어 분리(`dependencies` -> `bootJar`)
- `.dockerignore`
  - `.gradle-local`, `deploy`, `AGENTS.md`, `HELP.md` 제외

## 원인 분석 (배포 실패)
- 에러 로그의 `drone-scp error: Process exited with status 1`은 새 VM에서 `/opt/sw-connect` 하위 경로 권한이 준비되지 않은 상태에서 `scp`가 업로드를 시도하며 발생한 것으로 확인했습니다.
- 사전 SSH 단계에서 `/opt/sw-connect/shared/artifacts` 생성 및 소유권 보정을 수행하도록 수정했습니다.

## 테스트
- 로컬 검증:
  - `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew check` 통과

## 영향 범위
- API: 없음
- DB: 없음
- Config: 있음 (GitHub Actions, Dockerfile, dockerignore)
- Domain: 없음

## 관련 이슈
- Closes #38