### PR TITLE
[Chore] Develop 변경사항 Main 반영 머지 PR (CD 권한/캐시 최적화 포함)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,10 @@
 .git
 .github
 .gradle
+.gradle-local
 .idea
 build
+deploy
 secrets
 uploads
 logs
@@ -10,6 +12,9 @@ logs
 docs
 roles
 skills
+
+AGENTS.md
+HELP.md
 
 .env
 .env.*

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -73,6 +73,8 @@ jobs:
           tags: |
             ${{ env.image_name }}:${{ env.sha_tag }}
             ${{ env.image_name }}:${{ env.branch_latest_tag }}
+          cache-from: type=gha,scope=sw-connect-backend
+          cache-to: type=gha,mode=max,scope=sw-connect-backend
 
   deploy-validation:
     if: needs.build-and-push.outputs.head_branch == 'develop'
@@ -84,6 +86,21 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.build-and-push.outputs.head_sha }}
+
+      - name: Prepare deploy directories on VM
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.SW_VM_HOST }}
+          username: ${{ secrets.SW_VM_USER }}
+          key: ${{ secrets.SW_VM_SSH_KEY }}
+          port: ${{ secrets.SW_VM_PORT }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+            OWNER_USER="$(id -un)"
+            OWNER_GROUP="$(id -gn)"
+            sudo mkdir -p /opt/sw-connect/shared/artifacts
+            sudo chown -R "${OWNER_USER}:${OWNER_GROUP}" /opt/sw-connect
 
       - name: Upload deploy assets to VM
         uses: appleboy/scp-action@v0.1.7
@@ -133,6 +150,21 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.build-and-push.outputs.head_sha }}
+
+      - name: Prepare deploy directories on VM
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.SW_VM_HOST }}
+          username: ${{ secrets.SW_VM_USER }}
+          key: ${{ secrets.SW_VM_SSH_KEY }}
+          port: ${{ secrets.SW_VM_PORT }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+            OWNER_USER="$(id -un)"
+            OWNER_GROUP="$(id -gn)"
+            sudo mkdir -p /opt/sw-connect/shared/artifacts
+            sudo chown -R "${OWNER_USER}:${OWNER_GROUP}" /opt/sw-connect
 
       - name: Upload deploy assets to VM
         uses: appleboy/scp-action@v0.1.7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
+# syntax=docker/dockerfile:1.7
 FROM eclipse-temurin:21-jdk AS builder
 
 WORKDIR /workspace
 
 COPY gradlew settings.gradle.kts build.gradle.kts ./
 COPY gradle ./gradle
+
+RUN chmod +x ./gradlew
+RUN --mount=type=cache,target=/root/.gradle ./gradlew --no-daemon dependencies
+
 COPY config ./config
 COPY src ./src
 
-RUN chmod +x ./gradlew
-RUN ./gradlew --no-daemon bootJar
+RUN --mount=type=cache,target=/root/.gradle ./gradlew --no-daemon bootJar
 
 FROM eclipse-temurin:21-jre
 


### PR DESCRIPTION
## 배경
- `develop`에 반영된 CD 권한 보정 및 Docker 빌드 캐시 최적화 변경을 운영 브랜치(`main`)에도 동기화해야 합니다.

## 목적
- `develop -> main` 브랜치 동기화
- 운영 CD에서도 동일한 배포 안정성/속도 개선 적용

## 주요 반영 내용
- CD 배포 전 VM 경로 준비 단계 추가(`/opt/sw-connect` 권한/디렉터리 보정)
- Buildx GHA 캐시(`cache-from/cache-to`) 적용
- Dockerfile Gradle BuildKit 캐시 마운트 적용
- Docker build context 최적화(`.dockerignore`)

## 체크 포인트
- 머지 후 `main` 기준 `quality-gate` 성공 확인
- 이어서 `cd-deploy`의 `build-and-push`, `deploy-prod` 성공 확인
- `build-and-push` 시간 단축 여부(캐시 warm 이후) 확인