### PR TITLE
[Fix] CD 배포 시 GHCR 이미지 pull 인증 오류 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -113,6 +113,28 @@ jobs:
           target: "/opt/sw-connect/shared/artifacts"
           rm: true
 
+      - name: Login GHCR on VM and pre-pull image
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.SW_VM_HOST }}
+          username: ${{ secrets.SW_VM_USER }}
+          key: ${{ secrets.SW_VM_SSH_KEY }}
+          port: ${{ secrets.SW_VM_PORT }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+            GHCR_USERNAME='${{ secrets.GHCR_USERNAME }}'
+            GHCR_READ_TOKEN='${{ secrets.GHCR_READ_TOKEN }}'
+            IMAGE_REF='${{ needs.build-and-push.outputs.image_ref }}'
+
+            if [[ -z "$GHCR_USERNAME" || -z "$GHCR_READ_TOKEN" ]]; then
+              echo "GHCR credentials are required: GHCR_USERNAME, GHCR_READ_TOKEN"
+              exit 1
+            fi
+
+            printf '%s' "$GHCR_READ_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin >/dev/null
+            docker pull "$IMAGE_REF"
+
       - name: Run validation deploy
         uses: appleboy/ssh-action@v1.2.0
         with:
@@ -176,6 +198,28 @@ jobs:
           source: "deploy"
           target: "/opt/sw-connect/shared/artifacts"
           rm: true
+
+      - name: Login GHCR on VM and pre-pull image
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.SW_VM_HOST }}
+          username: ${{ secrets.SW_VM_USER }}
+          key: ${{ secrets.SW_VM_SSH_KEY }}
+          port: ${{ secrets.SW_VM_PORT }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+            GHCR_USERNAME='${{ secrets.GHCR_USERNAME }}'
+            GHCR_READ_TOKEN='${{ secrets.GHCR_READ_TOKEN }}'
+            IMAGE_REF='${{ needs.build-and-push.outputs.image_ref }}'
+
+            if [[ -z "$GHCR_USERNAME" || -z "$GHCR_READ_TOKEN" ]]; then
+              echo "GHCR credentials are required: GHCR_USERNAME, GHCR_READ_TOKEN"
+              exit 1
+            fi
+
+            printf '%s' "$GHCR_READ_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin >/dev/null
+            docker pull "$IMAGE_REF"
 
       - name: Run prod deploy
         uses: appleboy/ssh-action@v1.2.0

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -13,12 +13,15 @@
 - `SW_VM_PORT`
 - `SW_VM_USER`
 - `SW_VM_SSH_KEY`
+- `GHCR_USERNAME` (GHCR 패키지 read 가능한 계정명, 예: `bindoong01`)
+- `GHCR_READ_TOKEN` (GHCR `read:packages` 권한 PAT)
 - `SW_DEPLOY_ENV_BASE` (멀티라인 가능, `/opt/sw-connect/shared/.env.base`로 저장)
 - `SW_DEPLOY_ENV_PROD` (멀티라인 가능, `/opt/sw-connect/shared/.env.prod`로 저장)
 - `SW_DEPLOY_ENV_VALIDATION` (멀티라인 가능, `/opt/sw-connect/shared/.env.validation`로 저장)
 
 주의:
 - `GRAFANA_ADMIN_PASSWORD`는 필수 값이다(미설정 시 base stack 기동 실패).
+- `GHCR_READ_TOKEN`은 최소 권한 `read:packages`만 부여한다.
 
 ## npmplus 초기 1회 설정
 CD는 npmplus 컨테이너를 자동 기동하지만, 프록시 호스트 등록은 초기 1회 수동 설정이 필요하다.


### PR DESCRIPTION
## 작업 요약
- 배포 VM에서 GHCR 인증 후 이미지를 미리 pull하도록 `cd.yml`을 수정했습니다.
- `deploy-validation`, `deploy-prod` 양쪽 모두 동일한 인증 경로를 적용했습니다.
- 필수 시크릿(`GHCR_USERNAME`, `GHCR_READ_TOKEN`) 누락 시 즉시 실패하도록 방어 로직을 추가했습니다.
- 배포 문서에 GHCR 시크릿과 권한 범위를 반영했습니다.

## 원인
- 기존 워크플로는 GitHub Actions 러너에서 GHCR 로그인 후 push만 수행했고, VM에서는 GHCR 로그인 없이 private 이미지 pull을 시도했습니다.
- 그 결과 `unauthorized`로 `docker compose up`이 실패했습니다.

## 변경 파일
- `.github/workflows/cd.yml`
  - `Login GHCR on VM and pre-pull image` 단계 추가 (validation/prod)
- `deploy/README.md`
  - `GHCR_USERNAME`, `GHCR_READ_TOKEN(read:packages)` 시크릿 추가

## 테스트
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew check` 통과

## 영향 범위
- API: 없음
- DB: 없음
- Config: 있음 (GitHub Actions, 배포 문서)
- Domain: 없음

## 관련 이슈
- Closes #41