### PR TITLE
[Chore] Develop 변경사항 Main 반영 머지 PR (GHCR 인증 반영)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -113,6 +113,28 @@ jobs:
           target: "/opt/sw-connect/shared/artifacts"
           rm: true
 
+      - name: Login GHCR on VM and pre-pull image
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.SW_VM_HOST }}
+          username: ${{ secrets.SW_VM_USER }}
+          key: ${{ secrets.SW_VM_SSH_KEY }}
+          port: ${{ secrets.SW_VM_PORT }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+            GHCR_USERNAME='${{ secrets.GHCR_USERNAME }}'
+            GHCR_READ_TOKEN='${{ secrets.GHCR_READ_TOKEN }}'
+            IMAGE_REF='${{ needs.build-and-push.outputs.image_ref }}'
+
+            if [[ -z "$GHCR_USERNAME" || -z "$GHCR_READ_TOKEN" ]]; then
+              echo "GHCR credentials are required: GHCR_USERNAME, GHCR_READ_TOKEN"
+              exit 1
+            fi
+
+            printf '%s' "$GHCR_READ_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin >/dev/null
+            docker pull "$IMAGE_REF"
+
       - name: Run validation deploy
         uses: appleboy/ssh-action@v1.2.0
         with:
@@ -176,6 +198,28 @@ jobs:
           source: "deploy"
           target: "/opt/sw-connect/shared/artifacts"
           rm: true
+
+      - name: Login GHCR on VM and pre-pull image
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.SW_VM_HOST }}
+          username: ${{ secrets.SW_VM_USER }}
+          key: ${{ secrets.SW_VM_SSH_KEY }}
+          port: ${{ secrets.SW_VM_PORT }}
+          script_stop: true
+          script: |
+            set -euo pipefail
+            GHCR_USERNAME='${{ secrets.GHCR_USERNAME }}'
+            GHCR_READ_TOKEN='${{ secrets.GHCR_READ_TOKEN }}'
+            IMAGE_REF='${{ needs.build-and-push.outputs.image_ref }}'
+
+            if [[ -z "$GHCR_USERNAME" || -z "$GHCR_READ_TOKEN" ]]; then
+              echo "GHCR credentials are required: GHCR_USERNAME, GHCR_READ_TOKEN"
+              exit 1
+            fi
+
+            printf '%s' "$GHCR_READ_TOKEN" | docker login ghcr.io -u "$GHCR_USERNAME" --password-stdin >/dev/null
+            docker pull "$IMAGE_REF"
 
       - name: Run prod deploy
         uses: appleboy/ssh-action@v1.2.0

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -13,12 +13,15 @@
 - `SW_VM_PORT`
 - `SW_VM_USER`
 - `SW_VM_SSH_KEY`
+- `GHCR_USERNAME` (GHCR 패키지 read 가능한 계정명, 예: `bindoong01`)
+- `GHCR_READ_TOKEN` (GHCR `read:packages` 권한 PAT)
 - `SW_DEPLOY_ENV_BASE` (멀티라인 가능, `/opt/sw-connect/shared/.env.base`로 저장)
 - `SW_DEPLOY_ENV_PROD` (멀티라인 가능, `/opt/sw-connect/shared/.env.prod`로 저장)
 - `SW_DEPLOY_ENV_VALIDATION` (멀티라인 가능, `/opt/sw-connect/shared/.env.validation`로 저장)
 
 주의:
 - `GRAFANA_ADMIN_PASSWORD`는 필수 값이다(미설정 시 base stack 기동 실패).
+- `GHCR_READ_TOKEN`은 최소 권한 `read:packages`만 부여한다.
 
 ## npmplus 초기 1회 설정
 CD는 npmplus 컨테이너를 자동 기동하지만, 프록시 호스트 등록은 초기 1회 수동 설정이 필요하다.


### PR DESCRIPTION
## 배경
- `develop`에 반영된 GHCR 인증 기반 배포 수정사항을 `main`에도 동기화해야 운영 CD가 동일하게 동작합니다.

## 목적
- `develop -> main` 브랜치 동기화
- 운영 배포에서 GHCR private 이미지 pull 인증 경로 반영

## 주요 반영 내용
- 배포 VM에서 `docker login ghcr.io` 수행 후 이미지 pre-pull
- `GHCR_USERNAME`, `GHCR_READ_TOKEN` 누락 시 즉시 실패하도록 방어
- 배포 문서(필수 GitHub Secrets) 업데이트

## 체크 포인트
- 머지 후 `main` 기준 `quality-gate` 성공 확인
- 이어서 `cd-deploy`의 `deploy-prod` 성공 확인
- `unauthorized` 재발 여부 확인