### PR TITLE
[Fix] CD env 파일 오염 재발 방지 및 배포 무결성 검증 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -87,6 +87,14 @@ jobs:
         with:
           ref: ${{ needs.build-and-push.outputs.head_sha }}
 
+      - name: Write deploy env files on runner
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .cd-env
+          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_BASE }}' > .cd-env/.env.base
+          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_VALIDATION }}' > .cd-env/.env.validation
+
       - name: Prepare deploy directories on VM
         uses: appleboy/ssh-action@v1.2.0
         with:
@@ -99,7 +107,7 @@ jobs:
             set -euo pipefail
             OWNER_USER="$(id -un)"
             OWNER_GROUP="$(id -gn)"
-            sudo mkdir -p /opt/sw-connect/shared/artifacts
+            sudo mkdir -p /opt/sw-connect/shared /opt/sw-connect/shared/artifacts
             sudo chown -R "${OWNER_USER}:${OWNER_GROUP}" /opt/sw-connect
 
       - name: Upload deploy assets to VM
@@ -112,6 +120,17 @@ jobs:
           source: "deploy"
           target: "/opt/sw-connect/shared/artifacts"
           rm: true
+
+      - name: Upload deploy env files to VM
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.SW_VM_HOST }}
+          username: ${{ secrets.SW_VM_USER }}
+          key: ${{ secrets.SW_VM_SSH_KEY }}
+          port: ${{ secrets.SW_VM_PORT }}
+          source: ".cd-env/.env.base,.cd-env/.env.validation"
+          target: "/opt/sw-connect/shared"
+          overwrite: true
 
       - name: Login GHCR on VM and pre-pull image
         uses: appleboy/ssh-action@v1.2.0
@@ -145,16 +164,12 @@ jobs:
           script_stop: true
           script: |
             set -euo pipefail
-            mkdir -p /opt/sw-connect/shared
-
-            cat > /opt/sw-connect/shared/.env.base <<'EOF'
-            ${{ secrets.SW_DEPLOY_ENV_BASE }}
-            EOF
-
-            cat > /opt/sw-connect/shared/.env.validation <<'EOF'
-            ${{ secrets.SW_DEPLOY_ENV_VALIDATION }}
-            EOF
-
+            test -f /opt/sw-connect/shared/.env.base || { echo "Missing env file: /opt/sw-connect/shared/.env.base"; exit 1; }
+            test -f /opt/sw-connect/shared/.env.validation || { echo "Missing env file: /opt/sw-connect/shared/.env.validation"; exit 1; }
+            if grep -q '^DRONE_' /opt/sw-connect/shared/.env.base /opt/sw-connect/shared/.env.validation; then
+              echo "Invalid env file: DRONE_ artifact detected"
+              exit 1
+            fi
             chmod 600 /opt/sw-connect/shared/.env.base /opt/sw-connect/shared/.env.validation
 
             ROOT_DIR=/opt/sw-connect \
@@ -173,6 +188,14 @@ jobs:
         with:
           ref: ${{ needs.build-and-push.outputs.head_sha }}
 
+      - name: Write deploy env files on runner
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .cd-env
+          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_BASE }}' > .cd-env/.env.base
+          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_PROD }}' > .cd-env/.env.prod
+
       - name: Prepare deploy directories on VM
         uses: appleboy/ssh-action@v1.2.0
         with:
@@ -185,7 +208,7 @@ jobs:
             set -euo pipefail
             OWNER_USER="$(id -un)"
             OWNER_GROUP="$(id -gn)"
-            sudo mkdir -p /opt/sw-connect/shared/artifacts
+            sudo mkdir -p /opt/sw-connect/shared /opt/sw-connect/shared/artifacts
             sudo chown -R "${OWNER_USER}:${OWNER_GROUP}" /opt/sw-connect
 
       - name: Upload deploy assets to VM
@@ -198,6 +221,17 @@ jobs:
           source: "deploy"
           target: "/opt/sw-connect/shared/artifacts"
           rm: true
+
+      - name: Upload deploy env files to VM
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.SW_VM_HOST }}
+          username: ${{ secrets.SW_VM_USER }}
+          key: ${{ secrets.SW_VM_SSH_KEY }}
+          port: ${{ secrets.SW_VM_PORT }}
+          source: ".cd-env/.env.base,.cd-env/.env.prod"
+          target: "/opt/sw-connect/shared"
+          overwrite: true
 
       - name: Login GHCR on VM and pre-pull image
         uses: appleboy/ssh-action@v1.2.0
@@ -231,16 +265,12 @@ jobs:
           script_stop: true
           script: |
             set -euo pipefail
-            mkdir -p /opt/sw-connect/shared
-
-            cat > /opt/sw-connect/shared/.env.base <<'EOF'
-            ${{ secrets.SW_DEPLOY_ENV_BASE }}
-            EOF
-
-            cat > /opt/sw-connect/shared/.env.prod <<'EOF'
-            ${{ secrets.SW_DEPLOY_ENV_PROD }}
-            EOF
-
+            test -f /opt/sw-connect/shared/.env.base || { echo "Missing env file: /opt/sw-connect/shared/.env.base"; exit 1; }
+            test -f /opt/sw-connect/shared/.env.prod || { echo "Missing env file: /opt/sw-connect/shared/.env.prod"; exit 1; }
+            if grep -q '^DRONE_' /opt/sw-connect/shared/.env.base /opt/sw-connect/shared/.env.prod; then
+              echo "Invalid env file: DRONE_ artifact detected"
+              exit 1
+            fi
             chmod 600 /opt/sw-connect/shared/.env.base /opt/sw-connect/shared/.env.prod
 
             ROOT_DIR=/opt/sw-connect \

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -22,6 +22,8 @@
 주의:
 - `GRAFANA_ADMIN_PASSWORD`는 필수 값이다(미설정 시 base stack 기동 실패).
 - `GHCR_READ_TOKEN`은 최소 권한 `read:packages`만 부여한다.
+- CD는 러너에서 `.env.base/.env.prod/.env.validation` 파일을 생성해 VM으로 SCP 업로드한다(원격 heredoc 미사용).
+- 배포 직전 `.env`에 `DRONE_` 키가 포함되면 오염으로 간주하고 배포를 실패 처리한다.
 
 ## npmplus 초기 1회 설정
 CD는 npmplus 컨테이너를 자동 기동하지만, 프록시 호스트 등록은 초기 1회 수동 설정이 필요하다.


### PR DESCRIPTION
## 작업 요약
- CD에서 원격 SSH heredoc으로 env 파일을 생성하던 방식을 제거했습니다.
- GitHub Actions 러너에서 `.env.base/.env.validation/.env.prod` 파일을 생성한 뒤 SCP로 VM에 업로드하도록 변경했습니다.
- 배포 직전 env 파일에 `DRONE_` 키가 포함되면 즉시 실패하도록 무결성 검증을 추가했습니다.
- 관련 배포 문서에 변경된 방식과 검증 정책을 반영했습니다.

## 변경 상세
- `.github/workflows/cd.yml`
  - validation/prod 공통:
    - `Write deploy env files on runner` 단계 추가
    - `Upload deploy env files to VM` 단계 추가
    - 원격 heredoc(`cat <<EOF`) 제거
    - 배포 전 `DRONE_` 오염 검증 추가
  - 디렉터리 준비 단계에서 `/opt/sw-connect/shared` 생성 보강
- `deploy/README.md`
  - env 파일 전달 방식(러너 생성 + SCP 업로드) 명시
  - `DRONE_` 오염 감지 시 배포 실패 정책 명시

## 원인/해결
- 원인: SSH 액션 스크립트 기반 heredoc 작성 과정에서 `.env` 파일 오염이 발생해 `java: argument list too long` 및 health check 실패로 이어짐.
- 해결: 원격 생성 방식을 제거하고, 러너에서 생성한 정적 파일을 업로드해 오염 경로를 차단.

## 테스트
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew check` 통과

## 영향 범위
- API: 없음
- DB: 없음
- Config: 있음 (GitHub Actions, deploy 문서)
- Domain: 없음

## 관련 이슈
- Closes #44