### PR TITLE
[Chore] Develop 변경사항 Main 반영 머지 PR (env 오염 방지 반영)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -87,6 +87,14 @@ jobs:
         with:
           ref: ${{ needs.build-and-push.outputs.head_sha }}
 
+      - name: Write deploy env files on runner
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .cd-env
+          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_BASE }}' > .cd-env/.env.base
+          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_VALIDATION }}' > .cd-env/.env.validation
+
       - name: Prepare deploy directories on VM
         uses: appleboy/ssh-action@v1.2.0
         with:
@@ -99,7 +107,7 @@ jobs:
             set -euo pipefail
             OWNER_USER="$(id -un)"
             OWNER_GROUP="$(id -gn)"
-            sudo mkdir -p /opt/sw-connect/shared/artifacts
+            sudo mkdir -p /opt/sw-connect/shared /opt/sw-connect/shared/artifacts
             sudo chown -R "${OWNER_USER}:${OWNER_GROUP}" /opt/sw-connect
 
       - name: Upload deploy assets to VM
@@ -112,6 +120,17 @@ jobs:
           source: "deploy"
           target: "/opt/sw-connect/shared/artifacts"
           rm: true
+
+      - name: Upload deploy env files to VM
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.SW_VM_HOST }}
+          username: ${{ secrets.SW_VM_USER }}
+          key: ${{ secrets.SW_VM_SSH_KEY }}
+          port: ${{ secrets.SW_VM_PORT }}
+          source: ".cd-env/.env.base,.cd-env/.env.validation"
+          target: "/opt/sw-connect/shared"
+          overwrite: true
 
       - name: Login GHCR on VM and pre-pull image
         uses: appleboy/ssh-action@v1.2.0
@@ -145,16 +164,12 @@ jobs:
           script_stop: true
           script: |
             set -euo pipefail
-            mkdir -p /opt/sw-connect/shared
-
-            cat > /opt/sw-connect/shared/.env.base <<'EOF'
-            ${{ secrets.SW_DEPLOY_ENV_BASE }}
-            EOF
-
-            cat > /opt/sw-connect/shared/.env.validation <<'EOF'
-            ${{ secrets.SW_DEPLOY_ENV_VALIDATION }}
-            EOF
-
+            test -f /opt/sw-connect/shared/.env.base || { echo "Missing env file: /opt/sw-connect/shared/.env.base"; exit 1; }
+            test -f /opt/sw-connect/shared/.env.validation || { echo "Missing env file: /opt/sw-connect/shared/.env.validation"; exit 1; }
+            if grep -q '^DRONE_' /opt/sw-connect/shared/.env.base /opt/sw-connect/shared/.env.validation; then
+              echo "Invalid env file: DRONE_ artifact detected"
+              exit 1
+            fi
             chmod 600 /opt/sw-connect/shared/.env.base /opt/sw-connect/shared/.env.validation
 
             ROOT_DIR=/opt/sw-connect \
@@ -173,6 +188,14 @@ jobs:
         with:
           ref: ${{ needs.build-and-push.outputs.head_sha }}
 
+      - name: Write deploy env files on runner
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .cd-env
+          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_BASE }}' > .cd-env/.env.base
+          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_PROD }}' > .cd-env/.env.prod
+
       - name: Prepare deploy directories on VM
         uses: appleboy/ssh-action@v1.2.0
         with:
@@ -185,7 +208,7 @@ jobs:
             set -euo pipefail
             OWNER_USER="$(id -un)"
             OWNER_GROUP="$(id -gn)"
-            sudo mkdir -p /opt/sw-connect/shared/artifacts
+            sudo mkdir -p /opt/sw-connect/shared /opt/sw-connect/shared/artifacts
             sudo chown -R "${OWNER_USER}:${OWNER_GROUP}" /opt/sw-connect
 
       - name: Upload deploy assets to VM
@@ -198,6 +221,17 @@ jobs:
           source: "deploy"
           target: "/opt/sw-connect/shared/artifacts"
           rm: true
+
+      - name: Upload deploy env files to VM
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.SW_VM_HOST }}
+          username: ${{ secrets.SW_VM_USER }}
+          key: ${{ secrets.SW_VM_SSH_KEY }}
+          port: ${{ secrets.SW_VM_PORT }}
+          source: ".cd-env/.env.base,.cd-env/.env.prod"
+          target: "/opt/sw-connect/shared"
+          overwrite: true
 
       - name: Login GHCR on VM and pre-pull image
         uses: appleboy/ssh-action@v1.2.0
@@ -231,16 +265,12 @@ jobs:
           script_stop: true
           script: |
             set -euo pipefail
-            mkdir -p /opt/sw-connect/shared
-
-            cat > /opt/sw-connect/shared/.env.base <<'EOF'
-            ${{ secrets.SW_DEPLOY_ENV_BASE }}
-            EOF
-
-            cat > /opt/sw-connect/shared/.env.prod <<'EOF'
-            ${{ secrets.SW_DEPLOY_ENV_PROD }}
-            EOF
-
+            test -f /opt/sw-connect/shared/.env.base || { echo "Missing env file: /opt/sw-connect/shared/.env.base"; exit 1; }
+            test -f /opt/sw-connect/shared/.env.prod || { echo "Missing env file: /opt/sw-connect/shared/.env.prod"; exit 1; }
+            if grep -q '^DRONE_' /opt/sw-connect/shared/.env.base /opt/sw-connect/shared/.env.prod; then
+              echo "Invalid env file: DRONE_ artifact detected"
+              exit 1
+            fi
             chmod 600 /opt/sw-connect/shared/.env.base /opt/sw-connect/shared/.env.prod
 
             ROOT_DIR=/opt/sw-connect \

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -22,6 +22,8 @@
 주의:
 - `GRAFANA_ADMIN_PASSWORD`는 필수 값이다(미설정 시 base stack 기동 실패).
 - `GHCR_READ_TOKEN`은 최소 권한 `read:packages`만 부여한다.
+- CD는 러너에서 `.env.base/.env.prod/.env.validation` 파일을 생성해 VM으로 SCP 업로드한다(원격 heredoc 미사용).
+- 배포 직전 `.env`에 `DRONE_` 키가 포함되면 오염으로 간주하고 배포를 실패 처리한다.
 
 ## npmplus 초기 1회 설정
 CD는 npmplus 컨테이너를 자동 기동하지만, 프록시 호스트 등록은 초기 1회 수동 설정이 필요하다.


### PR DESCRIPTION
## 배경
- `develop`에 반영된 CD env 파일 오염 재발 방지 수정사항을 `main`에도 동기화해야 운영 CD가 동일하게 동작합니다.

## 목적
- `develop -> main` 브랜치 동기화
- 운영 배포에서 env 오염(`DRONE_` 주입) 재발 방지

## 주요 반영 내용
- CD env 전달 방식 변경: 원격 heredoc 제거, 러너 생성 + SCP 업로드
- 배포 직전 env 무결성 검증(`DRONE_` 키 감지 시 실패)
- 배포 문서 업데이트

## 체크 포인트
- 머지 후 `main` 기준 `quality-gate` 성공 확인
- 이어서 `cd-deploy`의 `deploy-prod` 성공 확인
- VM의 `/opt/sw-connect/shared/.env.*`에 `DRONE_` 키가 없는지 확인