### PR TITLE
[Fix] CD env 업로드 경로 보정 및 오염 잔재 정리

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -91,9 +91,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p .cd-env
-          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_BASE }}' > .cd-env/.env.base
-          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_VALIDATION }}' > .cd-env/.env.validation
+          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_BASE }}' > .env.base
+          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_VALIDATION }}' > .env.validation
 
       - name: Prepare deploy directories on VM
         uses: appleboy/ssh-action@v1.2.0
@@ -109,6 +108,8 @@ jobs:
             OWNER_GROUP="$(id -gn)"
             sudo mkdir -p /opt/sw-connect/shared /opt/sw-connect/shared/artifacts
             sudo chown -R "${OWNER_USER}:${OWNER_GROUP}" /opt/sw-connect
+            rm -rf /opt/sw-connect/shared/.cd-env
+            rm -f /opt/sw-connect/shared/.env.base /opt/sw-connect/shared/.env.validation
 
       - name: Upload deploy assets to VM
         uses: appleboy/scp-action@v0.1.7
@@ -128,7 +129,7 @@ jobs:
           username: ${{ secrets.SW_VM_USER }}
           key: ${{ secrets.SW_VM_SSH_KEY }}
           port: ${{ secrets.SW_VM_PORT }}
-          source: ".cd-env/.env.base,.cd-env/.env.validation"
+          source: ".env.base,.env.validation"
           target: "/opt/sw-connect/shared"
           overwrite: true
 
@@ -192,9 +193,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p .cd-env
-          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_BASE }}' > .cd-env/.env.base
-          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_PROD }}' > .cd-env/.env.prod
+          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_BASE }}' > .env.base
+          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_PROD }}' > .env.prod
 
       - name: Prepare deploy directories on VM
         uses: appleboy/ssh-action@v1.2.0
@@ -210,6 +210,8 @@ jobs:
             OWNER_GROUP="$(id -gn)"
             sudo mkdir -p /opt/sw-connect/shared /opt/sw-connect/shared/artifacts
             sudo chown -R "${OWNER_USER}:${OWNER_GROUP}" /opt/sw-connect
+            rm -rf /opt/sw-connect/shared/.cd-env
+            rm -f /opt/sw-connect/shared/.env.base /opt/sw-connect/shared/.env.prod
 
       - name: Upload deploy assets to VM
         uses: appleboy/scp-action@v0.1.7
@@ -229,7 +231,7 @@ jobs:
           username: ${{ secrets.SW_VM_USER }}
           key: ${{ secrets.SW_VM_SSH_KEY }}
           port: ${{ secrets.SW_VM_PORT }}
-          source: ".cd-env/.env.base,.cd-env/.env.prod"
+          source: ".env.base,.env.prod"
           target: "/opt/sw-connect/shared"
           overwrite: true
 


### PR DESCRIPTION
## 작업 요약
- env 파일을 `.cd-env` 디렉터리 경로로 업로드하던 방식을 수정해, VM의 `/opt/sw-connect/shared/.env.*` 경로를 정확히 덮어쓰도록 보정했습니다.
- 배포 준비 단계에서 과거 경로(`/opt/sw-connect/shared/.cd-env`)와 기존 env 파일을 정리하도록 추가해 오염 잔재 영향을 제거했습니다.

## 원인
- 이전 패치에서 SCP source가 `.cd-env/.env.*` 형태라 경로가 보존될 경우 `/opt/sw-connect/shared/.cd-env/.env.*`로 업로드될 수 있었습니다.
- 이 경우 기존 `/opt/sw-connect/shared/.env.*` 오염 파일이 남아 검증 단계에서 `DRONE_` 감지로 실패했습니다.

## 변경 상세
- `.github/workflows/cd.yml`
  - env 파일 생성 위치를 러너 루트(`.env.base/.env.prod/.env.validation`)로 변경
  - env 파일 업로드 source를 루트 파일 기준으로 변경
  - 준비 단계에서 `/opt/sw-connect/shared/.cd-env` 및 기존 `.env.*` 정리 추가

## 테스트
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew check` 통과

## 영향 범위
- API: 없음
- DB: 없음
- Config: 있음 (GitHub Actions)
- Domain: 없음

## 관련 이슈
- Closes #47