### PR TITLE
[Chore] Develop 변경사항 Main 반영 머지 PR (env 업로드 경로 보정)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -91,9 +91,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p .cd-env
-          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_BASE }}' > .cd-env/.env.base
-          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_VALIDATION }}' > .cd-env/.env.validation
+          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_BASE }}' > .env.base
+          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_VALIDATION }}' > .env.validation
 
       - name: Prepare deploy directories on VM
         uses: appleboy/ssh-action@v1.2.0
@@ -109,6 +108,8 @@ jobs:
             OWNER_GROUP="$(id -gn)"
             sudo mkdir -p /opt/sw-connect/shared /opt/sw-connect/shared/artifacts
             sudo chown -R "${OWNER_USER}:${OWNER_GROUP}" /opt/sw-connect
+            rm -rf /opt/sw-connect/shared/.cd-env
+            rm -f /opt/sw-connect/shared/.env.base /opt/sw-connect/shared/.env.validation
 
       - name: Upload deploy assets to VM
         uses: appleboy/scp-action@v0.1.7
@@ -128,7 +129,7 @@ jobs:
           username: ${{ secrets.SW_VM_USER }}
           key: ${{ secrets.SW_VM_SSH_KEY }}
           port: ${{ secrets.SW_VM_PORT }}
-          source: ".cd-env/.env.base,.cd-env/.env.validation"
+          source: ".env.base,.env.validation"
           target: "/opt/sw-connect/shared"
           overwrite: true
 
@@ -192,9 +193,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p .cd-env
-          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_BASE }}' > .cd-env/.env.base
-          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_PROD }}' > .cd-env/.env.prod
+          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_BASE }}' > .env.base
+          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_PROD }}' > .env.prod
 
       - name: Prepare deploy directories on VM
         uses: appleboy/ssh-action@v1.2.0
@@ -210,6 +210,8 @@ jobs:
             OWNER_GROUP="$(id -gn)"
             sudo mkdir -p /opt/sw-connect/shared /opt/sw-connect/shared/artifacts
             sudo chown -R "${OWNER_USER}:${OWNER_GROUP}" /opt/sw-connect
+            rm -rf /opt/sw-connect/shared/.cd-env
+            rm -f /opt/sw-connect/shared/.env.base /opt/sw-connect/shared/.env.prod
 
       - name: Upload deploy assets to VM
         uses: appleboy/scp-action@v0.1.7
@@ -229,7 +231,7 @@ jobs:
           username: ${{ secrets.SW_VM_USER }}
           key: ${{ secrets.SW_VM_SSH_KEY }}
           port: ${{ secrets.SW_VM_PORT }}
-          source: ".cd-env/.env.base,.cd-env/.env.prod"
+          source: ".env.base,.env.prod"
           target: "/opt/sw-connect/shared"
           overwrite: true
 


### PR DESCRIPTION
## 배경
- `develop`에 반영된 CD env 업로드 경로 보정 및 오염 잔재 정리 수정사항을 `main`에 동기화해야 운영 CD에서 동일하게 적용됩니다.

## 목적
- `develop -> main` 브랜치 동기화
- 운영 배포에서 `.env` 업로드 경로 오류 및 오염 검증 오탐 재발 방지

## 주요 반영 내용
- env 파일 생성 위치를 러너 루트 `.env.*`로 변경
- SCP source 경로를 루트 `.env.*`로 보정
- 배포 준비 단계에서 `/opt/sw-connect/shared/.cd-env` 및 기존 `.env.*` 정리

## 체크 포인트
- 머지 후 `main` CD `deploy-prod` 성공 여부 확인
- VM에서 `grep -n '^DRONE_' /opt/sw-connect/shared/.env.base /opt/sw-connect/shared/.env.prod` 결과가 비어있는지 확인