### PR TITLE
[Fix] CD env 숨김파일 업로드 의존 제거 및 원자 반영 적용

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -91,8 +91,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_BASE }}' > .env.base
-          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_VALIDATION }}' > .env.validation
+          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_BASE }}' > env_base
+          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_VALIDATION }}' > env_validation
 
       - name: Prepare deploy directories on VM
         uses: appleboy/ssh-action@v1.2.0
@@ -110,6 +110,7 @@ jobs:
             sudo chown -R "${OWNER_USER}:${OWNER_GROUP}" /opt/sw-connect
             rm -rf /opt/sw-connect/shared/.cd-env
             rm -f /opt/sw-connect/shared/.env.base /opt/sw-connect/shared/.env.validation
+            rm -f /opt/sw-connect/shared/env_base /opt/sw-connect/shared/env_validation
 
       - name: Upload deploy assets to VM
         uses: appleboy/scp-action@v0.1.7
@@ -129,7 +130,7 @@ jobs:
           username: ${{ secrets.SW_VM_USER }}
           key: ${{ secrets.SW_VM_SSH_KEY }}
           port: ${{ secrets.SW_VM_PORT }}
-          source: ".env.base,.env.validation"
+          source: "env_base,env_validation"
           target: "/opt/sw-connect/shared"
           overwrite: true
 
@@ -165,6 +166,11 @@ jobs:
           script_stop: true
           script: |
             set -euo pipefail
+            test -f /opt/sw-connect/shared/env_base || { echo "Missing env payload: /opt/sw-connect/shared/env_base"; exit 1; }
+            test -f /opt/sw-connect/shared/env_validation || { echo "Missing env payload: /opt/sw-connect/shared/env_validation"; exit 1; }
+            install -m 600 /opt/sw-connect/shared/env_base /opt/sw-connect/shared/.env.base
+            install -m 600 /opt/sw-connect/shared/env_validation /opt/sw-connect/shared/.env.validation
+            rm -f /opt/sw-connect/shared/env_base /opt/sw-connect/shared/env_validation
             test -f /opt/sw-connect/shared/.env.base || { echo "Missing env file: /opt/sw-connect/shared/.env.base"; exit 1; }
             test -f /opt/sw-connect/shared/.env.validation || { echo "Missing env file: /opt/sw-connect/shared/.env.validation"; exit 1; }
             if grep -q '^DRONE_' /opt/sw-connect/shared/.env.base /opt/sw-connect/shared/.env.validation; then
@@ -193,8 +199,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_BASE }}' > .env.base
-          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_PROD }}' > .env.prod
+          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_BASE }}' > env_base
+          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_PROD }}' > env_prod
 
       - name: Prepare deploy directories on VM
         uses: appleboy/ssh-action@v1.2.0
@@ -212,6 +218,7 @@ jobs:
             sudo chown -R "${OWNER_USER}:${OWNER_GROUP}" /opt/sw-connect
             rm -rf /opt/sw-connect/shared/.cd-env
             rm -f /opt/sw-connect/shared/.env.base /opt/sw-connect/shared/.env.prod
+            rm -f /opt/sw-connect/shared/env_base /opt/sw-connect/shared/env_prod
 
       - name: Upload deploy assets to VM
         uses: appleboy/scp-action@v0.1.7
@@ -231,7 +238,7 @@ jobs:
           username: ${{ secrets.SW_VM_USER }}
           key: ${{ secrets.SW_VM_SSH_KEY }}
           port: ${{ secrets.SW_VM_PORT }}
-          source: ".env.base,.env.prod"
+          source: "env_base,env_prod"
           target: "/opt/sw-connect/shared"
           overwrite: true
 
@@ -267,6 +274,11 @@ jobs:
           script_stop: true
           script: |
             set -euo pipefail
+            test -f /opt/sw-connect/shared/env_base || { echo "Missing env payload: /opt/sw-connect/shared/env_base"; exit 1; }
+            test -f /opt/sw-connect/shared/env_prod || { echo "Missing env payload: /opt/sw-connect/shared/env_prod"; exit 1; }
+            install -m 600 /opt/sw-connect/shared/env_base /opt/sw-connect/shared/.env.base
+            install -m 600 /opt/sw-connect/shared/env_prod /opt/sw-connect/shared/.env.prod
+            rm -f /opt/sw-connect/shared/env_base /opt/sw-connect/shared/env_prod
             test -f /opt/sw-connect/shared/.env.base || { echo "Missing env file: /opt/sw-connect/shared/.env.base"; exit 1; }
             test -f /opt/sw-connect/shared/.env.prod || { echo "Missing env file: /opt/sw-connect/shared/.env.prod"; exit 1; }
             if grep -q '^DRONE_' /opt/sw-connect/shared/.env.base /opt/sw-connect/shared/.env.prod; then

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -24,6 +24,7 @@
 - `GHCR_READ_TOKEN`은 최소 권한 `read:packages`만 부여한다.
 - CD는 러너에서 `.env.base/.env.prod/.env.validation` 파일을 생성해 VM으로 SCP 업로드한다(원격 heredoc 미사용).
 - 배포 직전 `.env`에 `DRONE_` 키가 포함되면 오염으로 간주하고 배포를 실패 처리한다.
+- 업로드 안정성을 위해 SCP 전송은 일반 파일명(`env_base/env_prod/env_validation`)으로 수행하고, VM에서 최종 `.env.*`로 반영한다.
 
 ## npmplus 초기 1회 설정
 CD는 npmplus 컨테이너를 자동 기동하지만, 프록시 호스트 등록은 초기 1회 수동 설정이 필요하다.


### PR DESCRIPTION
## 작업 요약
- CD env 전달에서 숨김파일(`.env.*`) 직접 업로드 의존을 제거했습니다.
- 러너에서 일반 파일(`env_base/env_validation/env_prod`) 생성 후 SCP 업로드하고, VM에서 `install`로 최종 `.env.*`를 원자적으로 반영하도록 변경했습니다.
- 준비 단계에서 이전 temp 파일 정리를 보강해 잔재 영향도 제거했습니다.

## 원인 정리
- 기존 방식은 `prepare` 단계에서 `.env.*`를 삭제한 뒤 숨김파일 업로드에 의존했기 때문에, 업로드 누락 시 즉시 `Missing env file`로 실패했습니다.
- 반복 실패를 끊기 위해 숨김파일 업로드 경로 자체를 제거했습니다.

## 변경 상세
- `.github/workflows/cd.yml`
  - validation/prod env 생성 파일명 변경: `.env.*` -> `env_*`
  - SCP source 변경: `env_base,env_validation` / `env_base,env_prod`
  - VM에서 `install -m 600`으로 `.env.*` 반영 후 temp 파일 삭제
  - 준비 단계 temp 파일 정리 보강
- `deploy/README.md`
  - 일반 파일 업로드 + VM 최종 반영 정책 명시

## 테스트
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew check` 통과

## 영향 범위
- API: 없음
- DB: 없음
- Config: 있음 (GitHub Actions, deploy 문서)
- Domain: 없음

## 관련 이슈
- Closes #50