### PR TITLE
[Fix] DeployScripts 배포 실패 시 컨테이너 진단 로그 추가

### DIFF
--- a/deploy/scripts/common.sh
+++ b/deploy/scripts/common.sh
@@ -127,6 +127,38 @@ wait_internal_http() {
     done
 }
 
+dump_container_diagnostics() {
+    local container_name="$1"
+    local tail_lines="${2:-200}"
+
+    log "----- diagnostics: ${container_name} -----"
+
+    if ! docker ps -a --format '{{.Names}}' | grep -Fxq "$container_name"; then
+        log "container not found: ${container_name}"
+        return 0
+    fi
+
+    docker ps -a --filter "name=^/${container_name}$" \
+        --format 'name={{.Names}} status={{.Status}} image={{.Image}}' || true
+    docker inspect --format \
+        'state={{.State.Status}} running={{.State.Running}} restarting={{.State.Restarting}} exitCode={{.State.ExitCode}} error={{.State.Error}} startedAt={{.State.StartedAt}} finishedAt={{.State.FinishedAt}}' \
+        "$container_name" || true
+    docker logs --tail "$tail_lines" "$container_name" 2>&1 || true
+
+    log "----- end diagnostics: ${container_name} -----"
+}
+
+dump_failure_diagnostics() {
+    local reason="$1"
+    shift
+
+    log "실패 진단 시작: ${reason}"
+    for container_name in "$@"; do
+        dump_container_diagnostics "$container_name"
+    done
+    log "실패 진단 종료: ${reason}"
+}
+
 read_state_value() {
     local key="$1"
     local state_file="$ROOT_DIR/prod/active_state.env"

--- a/deploy/scripts/deploy_prod.sh
+++ b/deploy/scripts/deploy_prod.sh
@@ -53,17 +53,31 @@ EOF
     compose_prod up -d "app_${target_color}"
 
     if ! wait_internal_http "http://sw-connect-prod-${target_color}:8080/actuator/health" 240; then
+        dump_failure_diagnostics \
+            "신규 ${target_color} 앱 health check 실패" \
+            "sw-connect-prod-${target_color}" \
+            sw-connect-prod-gateway \
+            sw-connect-validation-gateway
         compose_prod stop "app_${target_color}" || true
         fail "신규 ${target_color} 앱 health check 실패"
     fi
 
     if ! switch_prod_gateway "$target_color"; then
+        dump_failure_diagnostics \
+            "gateway 전환 실패" \
+            sw-connect-prod-gateway \
+            "sw-connect-prod-${target_color}"
         compose_prod stop "app_${target_color}" || true
         switch_prod_gateway "$previous_color" || true
         fail "gateway 전환 실패"
     fi
 
     if ! wait_internal_http "http://sw-connect-prod-gateway:8080/actuator/health" 180; then
+        dump_failure_diagnostics \
+            "gateway 전환 후 health check 실패" \
+            sw-connect-prod-gateway \
+            "sw-connect-prod-${target_color}" \
+            "sw-connect-prod-${previous_color}"
         switch_prod_gateway "$previous_color" || true
         compose_prod stop "app_${target_color}" || true
         fail "gateway 전환 후 health check 실패"

--- a/deploy/scripts/deploy_validation.sh
+++ b/deploy/scripts/deploy_validation.sh
@@ -26,10 +26,20 @@ EOF
     compose_validation up -d --force-recreate app_validation
 
     if ! wait_internal_http "http://sw-connect-validation:8080/actuator/health" 180; then
+        dump_failure_diagnostics \
+            "validation 앱 health check 실패" \
+            sw-connect-validation \
+            sw-connect-validation-gateway \
+            sw-connect-prod-gateway
         fail "validation 앱 health check 실패"
     fi
 
     if ! wait_internal_http "http://sw-connect-validation-gateway:8080/actuator/health" 180; then
+        dump_failure_diagnostics \
+            "validation gateway health check 실패" \
+            sw-connect-validation-gateway \
+            sw-connect-validation \
+            sw-connect-prod-gateway
         fail "validation gateway health check 실패"
     fi
 


### PR DESCRIPTION
## 작업 요약
- health check 실패 시 원인 분석이 가능하도록 배포 스크립트에 자동 컨테이너 진단 로그 출력을 추가했습니다.
- 공통 진단 함수(`dump_container_diagnostics`, `dump_failure_diagnostics`)를 `deploy/scripts/common.sh`에 추가했습니다.
- validation/prod 배포 스크립트의 실패 분기에서 관련 컨테이너 상태/inspect/logs를 자동 출력하도록 연결했습니다.

## 변경 파일
- `deploy/scripts/common.sh`
- `deploy/scripts/deploy_validation.sh`
- `deploy/scripts/deploy_prod.sh`

## 테스트 결과
- `bash -n deploy/scripts/common.sh deploy/scripts/deploy_validation.sh deploy/scripts/deploy_prod.sh` 통과
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew checkstyleMain spotbugsMain test jacocoTestReport jacocoTestCoverageVerification` 통과

## 영향 범위
- API: 없음
- DB: 없음
- Config/Deploy Script: 있음 (배포 실패 시 로그 출력 강화)
- Domain: 없음

## 관련 이슈
- Closes #52