### PR TITLE
[Fix] DockerCompose npmplus TZ 환경변수 추가

### DIFF
--- a/deploy/base/docker-compose.base.yml
+++ b/deploy/base/docker-compose.base.yml
@@ -58,6 +58,8 @@ services:
     image: ${NPMPLUS_IMAGE:-ghcr.io/zoeyvid/npmplus:latest}
     container_name: sw-connect-npmplus
     restart: unless-stopped
+    environment:
+      - TZ=Asia/Seoul
     ports:
       - "80:80"
       - "443:443/tcp"


### PR DESCRIPTION
## 작업 요약
- `deploy/base/docker-compose.base.yml`의 `npmplus` 서비스에 `TZ=Asia/Seoul` 환경변수를 추가했습니다.
- npmplus 컨테이너 로그의 `TZ is unset or invalid` 상태를 해소하기 위한 변경입니다.

## 변경 파일
- `deploy/base/docker-compose.base.yml`

## 검증
- `GRAFANA_ADMIN_PASSWORD=dummy docker compose -f deploy/base/docker-compose.base.yml config >/dev/null` 통과

## 영향 범위
- API: 없음
- DB: 없음
- Config/Deploy: base compose의 npmplus 런타임 환경변수
- Domain: 없음