### PR TITLE
[Fix] DockerCompose npmplus letsencrypt 마운트 제거

### DIFF
--- a/deploy/base/docker-compose.base.yml
+++ b/deploy/base/docker-compose.base.yml
@@ -67,7 +67,6 @@ services:
       - "127.0.0.1:81:81"
     volumes:
       - npmplus_data:/data
-      - npmplus_letsencrypt:/etc/letsencrypt
     depends_on:
       - prod-gateway
       - validation-gateway
@@ -112,6 +111,5 @@ networks:
 volumes:
   redis_data:
   npmplus_data:
-  npmplus_letsencrypt:
   prometheus_data:
   grafana_data:


### PR DESCRIPTION
## 작업 요약
- npmplus 컨테이너 로그의 마이그레이션 안내(`remove the /etc/letsencrypt mountpoint`)에 맞춰 `deploy/base/docker-compose.base.yml`에서 `/etc/letsencrypt` 마운트를 제거했습니다.
- 미사용 볼륨 정의(`npmplus_letsencrypt`)도 함께 제거했습니다.

## 변경 파일
- `deploy/base/docker-compose.base.yml`

## 검증
- `GRAFANA_ADMIN_PASSWORD=dummy docker compose -f deploy/base/docker-compose.base.yml config >/dev/null` 통과

## 영향 범위
- API: 없음
- DB: 없음
- Config/Deploy: npmplus 볼륨 마운트 구성
- Domain: 없음