### PR TITLE
[Release] develop 브랜치 운영 반영

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -91,8 +91,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_BASE }}' > .env.base
-          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_VALIDATION }}' > .env.validation
+          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_BASE }}' > env_base
+          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_VALIDATION }}' > env_validation
 
       - name: Prepare deploy directories on VM
         uses: appleboy/ssh-action@v1.2.0
@@ -110,6 +110,7 @@ jobs:
             sudo chown -R "${OWNER_USER}:${OWNER_GROUP}" /opt/sw-connect
             rm -rf /opt/sw-connect/shared/.cd-env
             rm -f /opt/sw-connect/shared/.env.base /opt/sw-connect/shared/.env.validation
+            rm -f /opt/sw-connect/shared/env_base /opt/sw-connect/shared/env_validation
 
       - name: Upload deploy assets to VM
         uses: appleboy/scp-action@v0.1.7
@@ -129,7 +130,7 @@ jobs:
           username: ${{ secrets.SW_VM_USER }}
           key: ${{ secrets.SW_VM_SSH_KEY }}
           port: ${{ secrets.SW_VM_PORT }}
-          source: ".env.base,.env.validation"
+          source: "env_base,env_validation"
           target: "/opt/sw-connect/shared"
           overwrite: true
 
@@ -165,6 +166,11 @@ jobs:
           script_stop: true
           script: |
             set -euo pipefail
+            test -f /opt/sw-connect/shared/env_base || { echo "Missing env payload: /opt/sw-connect/shared/env_base"; exit 1; }
+            test -f /opt/sw-connect/shared/env_validation || { echo "Missing env payload: /opt/sw-connect/shared/env_validation"; exit 1; }
+            install -m 600 /opt/sw-connect/shared/env_base /opt/sw-connect/shared/.env.base
+            install -m 600 /opt/sw-connect/shared/env_validation /opt/sw-connect/shared/.env.validation
+            rm -f /opt/sw-connect/shared/env_base /opt/sw-connect/shared/env_validation
             test -f /opt/sw-connect/shared/.env.base || { echo "Missing env file: /opt/sw-connect/shared/.env.base"; exit 1; }
             test -f /opt/sw-connect/shared/.env.validation || { echo "Missing env file: /opt/sw-connect/shared/.env.validation"; exit 1; }
             if grep -q '^DRONE_' /opt/sw-connect/shared/.env.base /opt/sw-connect/shared/.env.validation; then
@@ -193,8 +199,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_BASE }}' > .env.base
-          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_PROD }}' > .env.prod
+          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_BASE }}' > env_base
+          printf '%s\n' '${{ secrets.SW_DEPLOY_ENV_PROD }}' > env_prod
 
       - name: Prepare deploy directories on VM
         uses: appleboy/ssh-action@v1.2.0
@@ -212,6 +218,7 @@ jobs:
             sudo chown -R "${OWNER_USER}:${OWNER_GROUP}" /opt/sw-connect
             rm -rf /opt/sw-connect/shared/.cd-env
             rm -f /opt/sw-connect/shared/.env.base /opt/sw-connect/shared/.env.prod
+            rm -f /opt/sw-connect/shared/env_base /opt/sw-connect/shared/env_prod
 
       - name: Upload deploy assets to VM
         uses: appleboy/scp-action@v0.1.7
@@ -231,7 +238,7 @@ jobs:
           username: ${{ secrets.SW_VM_USER }}
           key: ${{ secrets.SW_VM_SSH_KEY }}
           port: ${{ secrets.SW_VM_PORT }}
-          source: ".env.base,.env.prod"
+          source: "env_base,env_prod"
           target: "/opt/sw-connect/shared"
           overwrite: true
 
@@ -267,6 +274,11 @@ jobs:
           script_stop: true
           script: |
             set -euo pipefail
+            test -f /opt/sw-connect/shared/env_base || { echo "Missing env payload: /opt/sw-connect/shared/env_base"; exit 1; }
+            test -f /opt/sw-connect/shared/env_prod || { echo "Missing env payload: /opt/sw-connect/shared/env_prod"; exit 1; }
+            install -m 600 /opt/sw-connect/shared/env_base /opt/sw-connect/shared/.env.base
+            install -m 600 /opt/sw-connect/shared/env_prod /opt/sw-connect/shared/.env.prod
+            rm -f /opt/sw-connect/shared/env_base /opt/sw-connect/shared/env_prod
             test -f /opt/sw-connect/shared/.env.base || { echo "Missing env file: /opt/sw-connect/shared/.env.base"; exit 1; }
             test -f /opt/sw-connect/shared/.env.prod || { echo "Missing env file: /opt/sw-connect/shared/.env.prod"; exit 1; }
             if grep -q '^DRONE_' /opt/sw-connect/shared/.env.base /opt/sw-connect/shared/.env.prod; then

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -24,6 +24,7 @@
 - `GHCR_READ_TOKEN`은 최소 권한 `read:packages`만 부여한다.
 - CD는 러너에서 `.env.base/.env.prod/.env.validation` 파일을 생성해 VM으로 SCP 업로드한다(원격 heredoc 미사용).
 - 배포 직전 `.env`에 `DRONE_` 키가 포함되면 오염으로 간주하고 배포를 실패 처리한다.
+- 업로드 안정성을 위해 SCP 전송은 일반 파일명(`env_base/env_prod/env_validation`)으로 수행하고, VM에서 최종 `.env.*`로 반영한다.
 
 ## npmplus 초기 1회 설정
 CD는 npmplus 컨테이너를 자동 기동하지만, 프록시 호스트 등록은 초기 1회 수동 설정이 필요하다.

--- a/deploy/base/docker-compose.base.yml
+++ b/deploy/base/docker-compose.base.yml
@@ -58,6 +58,8 @@ services:
     image: ${NPMPLUS_IMAGE:-ghcr.io/zoeyvid/npmplus:latest}
     container_name: sw-connect-npmplus
     restart: unless-stopped
+    environment:
+      - TZ=Asia/Seoul
     ports:
       - "80:80"
       - "443:443/tcp"

--- a/deploy/base/docker-compose.base.yml
+++ b/deploy/base/docker-compose.base.yml
@@ -67,7 +67,6 @@ services:
       - "127.0.0.1:81:81"
     volumes:
       - npmplus_data:/data
-      - npmplus_letsencrypt:/etc/letsencrypt
     depends_on:
       - prod-gateway
       - validation-gateway
@@ -112,6 +111,5 @@ networks:
 volumes:
   redis_data:
   npmplus_data:
-  npmplus_letsencrypt:
   prometheus_data:
   grafana_data:

--- a/deploy/scripts/common.sh
+++ b/deploy/scripts/common.sh
@@ -127,6 +127,38 @@ wait_internal_http() {
     done
 }
 
+dump_container_diagnostics() {
+    local container_name="$1"
+    local tail_lines="${2:-200}"
+
+    log "----- diagnostics: ${container_name} -----"
+
+    if ! docker ps -a --format '{{.Names}}' | grep -Fxq "$container_name"; then
+        log "container not found: ${container_name}"
+        return 0
+    fi
+
+    docker ps -a --filter "name=^/${container_name}$" \
+        --format 'name={{.Names}} status={{.Status}} image={{.Image}}' || true
+    docker inspect --format \
+        'state={{.State.Status}} running={{.State.Running}} restarting={{.State.Restarting}} exitCode={{.State.ExitCode}} error={{.State.Error}} startedAt={{.State.StartedAt}} finishedAt={{.State.FinishedAt}}' \
+        "$container_name" || true
+    docker logs --tail "$tail_lines" "$container_name" 2>&1 || true
+
+    log "----- end diagnostics: ${container_name} -----"
+}
+
+dump_failure_diagnostics() {
+    local reason="$1"
+    shift
+
+    log "실패 진단 시작: ${reason}"
+    for container_name in "$@"; do
+        dump_container_diagnostics "$container_name"
+    done
+    log "실패 진단 종료: ${reason}"
+}
+
 read_state_value() {
     local key="$1"
     local state_file="$ROOT_DIR/prod/active_state.env"

--- a/deploy/scripts/deploy_prod.sh
+++ b/deploy/scripts/deploy_prod.sh
@@ -53,17 +53,31 @@ EOF
     compose_prod up -d "app_${target_color}"
 
     if ! wait_internal_http "http://sw-connect-prod-${target_color}:8080/actuator/health" 240; then
+        dump_failure_diagnostics \
+            "신규 ${target_color} 앱 health check 실패" \
+            "sw-connect-prod-${target_color}" \
+            sw-connect-prod-gateway \
+            sw-connect-validation-gateway
         compose_prod stop "app_${target_color}" || true
         fail "신규 ${target_color} 앱 health check 실패"
     fi
 
     if ! switch_prod_gateway "$target_color"; then
+        dump_failure_diagnostics \
+            "gateway 전환 실패" \
+            sw-connect-prod-gateway \
+            "sw-connect-prod-${target_color}"
         compose_prod stop "app_${target_color}" || true
         switch_prod_gateway "$previous_color" || true
         fail "gateway 전환 실패"
     fi
 
     if ! wait_internal_http "http://sw-connect-prod-gateway:8080/actuator/health" 180; then
+        dump_failure_diagnostics \
+            "gateway 전환 후 health check 실패" \
+            sw-connect-prod-gateway \
+            "sw-connect-prod-${target_color}" \
+            "sw-connect-prod-${previous_color}"
         switch_prod_gateway "$previous_color" || true
         compose_prod stop "app_${target_color}" || true
         fail "gateway 전환 후 health check 실패"

--- a/deploy/scripts/deploy_validation.sh
+++ b/deploy/scripts/deploy_validation.sh
@@ -26,10 +26,20 @@ EOF
     compose_validation up -d --force-recreate app_validation
 
     if ! wait_internal_http "http://sw-connect-validation:8080/actuator/health" 180; then
+        dump_failure_diagnostics \
+            "validation 앱 health check 실패" \
+            sw-connect-validation \
+            sw-connect-validation-gateway \
+            sw-connect-prod-gateway
         fail "validation 앱 health check 실패"
     fi
 
     if ! wait_internal_http "http://sw-connect-validation-gateway:8080/actuator/health" 180; then
+        dump_failure_diagnostics \
+            "validation gateway health check 실패" \
+            sw-connect-validation-gateway \
+            sw-connect-validation \
+            sw-connect-prod-gateway
         fail "validation gateway health check 실패"
     fi
 


### PR DESCRIPTION
## 작업 요약
- `develop` 최신 커밋을 `main`에 반영하기 위한 운영 릴리스 PR입니다.
- 머지 시 `cd-deploy` 워크플로우에서 `main` 기준 운영 배포가 트리거됩니다.

## 포함 변경
- 최근 배포 스크립트 안정화 변경
- npmplus 런타임 구성 정리 변경

## 확인 사항
- `quality-gate` 통과 후 머지 진행
- 머지 후 `cd-deploy`의 `deploy-prod` 성공 여부 확인
- 배포 후 `https://api.hdb01.site/actuator/health` 확인